### PR TITLE
Update for user-api

### DIFF
--- a/bitski-common/Cargo.toml
+++ b/bitski-common/Cargo.toml
@@ -16,29 +16,44 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 
-actix-web = ["dep:actix-web", "actix-web-opentelemetry", "http"]
-diesel = ["async-trait", "dep:diesel", "diesel-tracing", "r2d2"]
+actix = ["dep:actix"]
+actix-web = ["dep:actix-web", "actix-web-opentelemetry", "http", "serde_json"]
+awc = ["dep:awc"]
+bcrypt = ["dep:bcrypt"]
+diesel = ["async-trait", "dep:diesel", "r2d2"]
+lettre = ["dep:lettre", "lettre_email"]
+oauth2 = ["dep:oauth2"]
+reqwest = ["dep:reqwest"]
 test = []
 tonic = ["dep:tonic", "tower"]
 tower = ["dep:tower", "tower-http"]
 
 [dependencies]
+actix = { version = "0.13.0", optional = true, default-features = false }
 actix-web = { version = "4.0.1", optional = true }
 actix-web-opentelemetry = { git = "https://github.com/BitskiCo/actix-web-opentelemetry", features = [
     "metrics",
 ], optional = true }
 anyhow = "1.0.57"
 async-trait = { version = "0.1.53", optional = true }
+awc = { version = "3.0.0", default-features = false, optional = true }
+bcrypt = { version = "0.13.0", default-features = false, features = [
+    "std",
+], optional = true }
 diesel = { version = "1.4.8", features = ["postgres", "r2d2"], optional = true }
-diesel-tracing = { version = "0.1.5", features = ["postgres"], optional = true }
 dotenv = "0.15.0"
 http = { version = "0.2.7", optional = true }
 hyper = "0.14.18"
+lettre = { version = "0.9.6", optional = true }
+lettre_email = { version = "0.9.4", optional = true }
+oauth2 = { version = "4.2.0", optional = true, default-features = false, features = ["reqwest"] }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio-current-thread"] }
 opentelemetry-otlp = { version = "0.10.0", features = ["metrics"] }
 opentelemetry-semantic-conventions = "0.9.0"
 opentelemetry-zipkin = "0.15.0"
 r2d2 = { version = "0.8.9", optional = true }
+reqwest = { version = "0.11.10", optional = true, default-features = false }
+serde_json = { version = "1.0.81", optional = true }
 tokio = { version = "1.18.0", features = ["rt"] }
 tonic = { version = "0.7.1", optional = true }
 tower = { version = "0.4.12", optional = true }
@@ -53,5 +68,5 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 uuid = { version = "1.0.0", features = ["v4"] }
 
 [dev-dependencies]
-bitski-common = { path = ".", features = ["tower"] }
+bitski-common = { path = ".", features = ["tonic", "tower"] }
 tonic-health = "0.6.0"

--- a/bitski-common/src/task.rs
+++ b/bitski-common/src/task.rs
@@ -4,7 +4,12 @@ use std::future::Future;
 
 use opentelemetry::trace::FutureExt as _;
 
-/// Spawns a new asynchronous task with Tokio, propagating the current OpenTelemetry context.
+/// Spawns a new asynchronous task with Tokio.
+///
+/// Propagates the current OpenTelemetry context. Unless the task needs to run
+/// concurrently, prefer [`spawn_local`].
+///
+/// See [`tokio::spawn`].
 pub fn spawn<T>(future: T) -> tokio::task::JoinHandle<T::Output>
 where
     T: Future + Send + 'static,
@@ -13,7 +18,24 @@ where
     tokio::spawn(future.with_current_context())
 }
 
-/// Spawns a blocking task with Tokio, propagating the current OpenTelemetry context.
+/// Spawns a new asynchronous task with Tokio, on the current thread.
+///
+/// Propagates the current OpenTelemetry context.
+///
+/// See [`tokio::task::spawn_local`].
+pub fn spawn_local<T>(future: T) -> tokio::task::JoinHandle<T::Output>
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    tokio::task::spawn_local(future.with_current_context())
+}
+
+/// Spawns a blocking task with Tokio.
+///
+/// Propagates the current OpenTelemetry context.
+///
+/// See [`tokio::task::spawn_blocking`].
 pub fn spawn_blocking<F, R>(f: F) -> tokio::task::JoinHandle<R>
 where
     F: FnOnce() -> R + Send + 'static,

--- a/bitski-common/src/tower/mod.rs
+++ b/bitski-common/src/tower/mod.rs
@@ -30,7 +30,7 @@ const DEFAULT_SERVER_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 /// ```rust,no_run
 /// use anyhow::Result;
 /// use bitski_common::{
-///     env::{init_env, parse_env_addr},
+///     env::{init_env, parse_env_addr_or_default},
 ///     telemetry::{init_instruments, shutdown_instruments},
 ///     tower::{BitskiLayer, BitskiLayerExt as _},
 /// };
@@ -49,7 +49,7 @@ const DEFAULT_SERVER_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 ///         .set_service_status("", tonic_health::ServingStatus::Serving)
 ///         .await;
 ///
-///     let addr = parse_env_addr()?;
+///     let addr = parse_env_addr_or_default()?;
 ///     tracing::info!("Listening on {}", addr);
 ///
 ///     Server::builder()


### PR DESCRIPTION
* Added more convenience `env` parsers
* Added error converters for errors used in `user-api`
* Added `spawn_local` for `actix-web` and `awc` support
* Removed `diesel-tracing`, which [doesn't support CockroachDB][crdb-issue]
* Updated docstrings

[crdb-issue]: https://github.com/CQCL/diesel-tracing/issues/12