### PR TITLE
Make `init_instruments` a macro

### DIFF
--- a/bitski-common/src/actix_web.rs
+++ b/bitski-common/src/actix_web.rs
@@ -12,7 +12,7 @@ pub use actix_web::*;
 /// use bitski_common::{
 ///     actix_web_app,
 ///     env::{init_env, parse_env_addr_or_default},
-///     telemetry::{init_instruments, shutdown_instruments},
+///     init_instruments, shutdown_instruments,
 /// };
 ///
 /// async fn index() -> &'static str {
@@ -22,7 +22,7 @@ pub use actix_web::*;
 /// #[actix_web::main]
 /// async fn main() -> Result<()> {
 ///     init_env();
-///     init_instruments()?;
+///     init_instruments!()?;
 ///
 ///     // listens on `localhost:8000`
 ///     let addr = parse_env_addr_or_default()?;

--- a/bitski-common/src/lib.rs
+++ b/bitski-common/src/lib.rs
@@ -20,6 +20,7 @@ pub use actix_web_opentelemetry;
 pub use opentelemetry;
 
 pub use crate::error::Error;
+pub use crate::telemetry::shutdown_instruments;
 
 /// [`Result`] with a default error type of [`Error`].
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/bitski-common/src/tower/mod.rs
+++ b/bitski-common/src/tower/mod.rs
@@ -31,7 +31,7 @@ const DEFAULT_SERVER_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 /// use anyhow::Result;
 /// use bitski_common::{
 ///     env::{init_env, parse_env_addr_or_default},
-///     telemetry::{init_instruments, shutdown_instruments},
+///     init_instruments, shutdown_instruments,
 ///     tower::{BitskiLayer, BitskiLayerExt as _},
 /// };
 /// use hyper::header;
@@ -40,7 +40,7 @@ const DEFAULT_SERVER_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 /// #[tokio::main]
 /// async fn main() -> Result<()> {
 ///     init_env();
-///     init_instruments()?;
+///     init_instruments!()?;
 ///
 ///     let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
 ///


### PR DESCRIPTION
The `init_instruments` function was setting the default service name to `bitski-common`. Instead, we want to set it to the name of the calling crate.