### PR TITLE
Support test tracing

### DIFF
--- a/bitski-common/src/telemetry.rs
+++ b/bitski-common/src/telemetry.rs
@@ -88,12 +88,15 @@ fn init_tracing(resources: &[KeyValue]) -> Result<()> {
     #[cfg(not(any(test, feature = "test")))]
     let ansi = false;
 
-    tracing_subscriber::Registry::default()
-        .with(tracing_subscriber::EnvFilter::from_default_env())
-        .with(tracing_subscriber::fmt::layer().with_ansi(ansi))
-        .with(tracing_opentelemetry::layer().with_tracer(tracer))
-        .init();
-
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        tracing_subscriber::Registry::default()
+            .with(tracing_subscriber::EnvFilter::from_default_env())
+            .with(tracing_subscriber::fmt::layer().with_ansi(ansi))
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .init();
+    });
     Ok(())
 }
 

--- a/bitski-common/src/telemetry.rs
+++ b/bitski-common/src/telemetry.rs
@@ -30,7 +30,8 @@ macro_rules! init_instruments {
     };
 }
 
-#[doc(hidden)]
+#[cfg(feature = "test")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test")))]
 #[macro_export]
 macro_rules! init_instruments_for_test {
     () => {
@@ -57,7 +58,8 @@ pub fn init_instruments_with_defaults(
     Ok(metrics)
 }
 
-#[doc(hidden)]
+#[cfg(feature = "test")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test")))]
 pub fn init_instruments_with_defaults_for_test(
     default_service_name: &str,
     default_service_version: &str,
@@ -108,6 +110,8 @@ fn init_tracing(resources: &[KeyValue]) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "test")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test")))]
 fn init_tracing_for_test() {
     use std::sync::Once;
     static ONCE: Once = Once::new();


### PR DESCRIPTION
was unable to use tracing with tests in contract-api [(related pr)](https://github.com/BitskiCo/bitski-common-rs/pull/39) so updated here to fix that,

also had to make it only ever add tracing once to avoid errors with tests where setting up tracing gets called multiple times, otherwise it would panic with `failed to set global default subscriber: SetGlobalDefaultError { _no_construct: () }`