### PR TITLE
Remove `Send` constraint from `spawn_local`

### DIFF
--- a/bitski-common/src/task.rs
+++ b/bitski-common/src/task.rs
@@ -25,8 +25,8 @@ where
 /// See [`tokio::task::spawn_local`].
 pub fn spawn_local<T>(future: T) -> tokio::task::JoinHandle<T::Output>
 where
-    T: Future + Send + 'static,
-    T::Output: Send + 'static,
+    T: Future + 'static,
+    T::Output: 'static,
 {
     tokio::task::spawn_local(future.with_current_context())
 }


### PR DESCRIPTION
`Send` constraint is not needed for `spawn_local`.