### PR TITLE
Pass through awc dep to actix-web-opentelemetry

### DIFF
--- a/bitski-common/Cargo.toml
+++ b/bitski-common/Cargo.toml
@@ -24,7 +24,7 @@ actix-web = [
   "sentry-actix",
   "serde_json",
 ]
-awc = ["dep:awc"]
+awc = ["dep:awc", "actix-web-opentelemetry/awc"]
 bcrypt = ["dep:bcrypt"]
 diesel = ["async-trait", "dep:diesel", "r2d2"]
 humantime = ["dep:humantime"]


### PR DESCRIPTION
Needed to use the awc client ext for injecting trace context